### PR TITLE
Use certbot latest not outdated rolling release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ COPY . .
 RUN cargo install cargo-deb
 RUN cargo deb --target x86_64-unknown-linux-musl
 
-FROM certbot/certbot:rolling
+FROM certbot/certbot:latest
 VOLUME /etc/letsencrypt
 COPY --from=builder /home/rust/src/target/x86_64-unknown-linux-musl/release/letsencrypt-inwx /usr/bin/
 COPY etc/* /usr/lib/letsencrypt-inwx/


### PR DESCRIPTION
The certbot with the tag "rolling" hasn't been updated for 2 years now. To use the latest version of certbot the tag "latest" must be used.

Tag rolling has certbot in version: 0.33.0.dev0 
Tag latest has certbot in version: 1.6.0

It would be nice if you could run circle-ci regularly to publish new version of the container kegato/letsencrypt-inwx so that it always uses the latest certbot version. 

Thanks for your work! 